### PR TITLE
Add singularize function

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Most of the EnglishText.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2015, 2016, 2017: Fengyang Wang.
+> Copyright (c) 2015, 2016, 2017: Fengyang Wang and other contributors.
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently this package includes six features:
  - `english` for converting a positive integer to an English-language wordy
    representation, and the inverse function `unenglish` to convert the wordy
    representation back.
- - `pluralize` to pluralize a noun
+ - `pluralize` to pluralize a noun, and the inverse function `singularize`
  - `ItemList` to create a list of objects
  - `ItemQuantity` to associate a noun with a number
  - `sentences` to iterate over the sentences of a text

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,7 @@ unenglish
 ```@docs
 ItemQuantity
 pluralize
+singularize
 ```
 
 ## Lists of Nouns and Adjectives
@@ -34,3 +35,8 @@ ItemList
 ```@docs
 sentences
 ```
+
+## Citations
+
+- Conway, D. M. (1998, August). An algorithmic approach to english
+  pluralization. In Proceedings of the Second Annual Perl Conference.

--- a/src/pluralize.jl
+++ b/src/pluralize.jl
@@ -44,7 +44,6 @@ const IRREGULAR_CLS = merge(IRREGULAR_ANG, Dict(
     "brother" => "brethren",
     "cow" => "kine",
     "die" => "dice",
-    "genie" => "genii",
     "money" => "monies",
     "octopus" => "octopodes"))
 
@@ -58,7 +57,7 @@ const WORD_NOINFLECT = Set([
     "trout", "diabetes", "mews", "tuna", "djinn", "mumps", "whiting", "eland",
     "news", "wildebeest", "elk", "pincers"])
 
-# table A.3 -- currently unused
+# table A.3 — currently used only for unpluralization
 const SINGLE_S = Set([
     "polis", "asbestos", "glottis", "rhinoceros", "canvas", "lens", "chaos",
     "ibis", "marquis", "caddis", "epidermis", "cannabis", "cosmos", "pathos",
@@ -192,8 +191,9 @@ const SUFFIX_CLASSICAL = Dict(
 
 const SUFFIX_COMMON = Dict(
     r"[cs]h$" => (1, "hes"),
-    r"ss$" => (2, "sses"),
-    r"x$" => (1, "xes"),
+    r"[xs]$" => (0, "es"),
+    r"iz$" => (2, "izzes"),
+    r"[^i]z$" => (1, "zes"),
     r"[aeiou]y$" => (1, "ys"),
     r"[A-Z].*y$" => (1, "ys"),
     r"y$" => (1, "ies"),
@@ -292,7 +292,7 @@ function pluralize(word; classical=true)
         end
     end
 
-    # suffixes ending in -es, -f, -fe, -y, -ys
+    # suffixes ending in -ss, -es, -f, -fe, -y, -ys
     com = suffix_inflect(SUFFIX_COMMON, word)
     if !isnull(com)
         return get(com)
@@ -312,7 +312,9 @@ function pluralize(word; classical=true)
     word * "s"
 end
 
+include("singularize.jl")
+
 end  # module Pluralize
 
-import .Pluralize: pluralize
-export pluralize
+import .Pluralize: pluralize, singularize
+export pluralize, singularize

--- a/src/singularize.jl
+++ b/src/singularize.jl
@@ -1,0 +1,83 @@
+#=――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
+    NOTE
+    The algorithm and rules used for unpluralizing English words was originated
+    by the Inflector .NET project, and is copyright Andrew Peters, Scott
+    Kirkland and other contributors. It is made available under the MIT
+    license. Modifications may have been made to the original algorithm.
+
+    The Inflector .NET is hosted on GitHub at the following URL
+    <https://github.com/srkirkland/Inflector>
+――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――=#
+
+export singularize
+
+const SINGULARIZE_RULES = [
+    r"geese$"               => s"goose",
+    r"feet$"                => s"foot",
+    r"men$"                 => s"man",
+    r"moves$"               => s"move",
+    r"monies$"              => s"money",
+    r"matrices$"            => s"matrix",
+    r"i$"                   => s"us",
+    r"ae$"                  => s"a",
+    r"podes$"               => s"pus",
+    r"(qu|wh)izzes$"        => s"\1iz",
+    r"zes"                  => s"z",
+    r"(vert|ind)ices$"      => s"\1ex",
+    r"(cris|ax|test)es$"    => s"\1is",
+    r"shoes$"               => s"shoe",
+    r"oes$"                 => s"o",
+    r"([ml])ice$"           => s"\1ouse",
+    r"(x|ch|ss|sh)es$"      => s"\1",
+    r"movies$"              => s"movie",
+    r"([^aeiouy]|qu)ies$"   => s"\1y",
+    r"([lr])ves$"           => s"\1f",
+    r"([ht])ives$"          => s"\1ive",
+    r"([^f])ves$"           => s"\1fe",
+    r"[us]ses$"             => s"us",
+    r"ses$"                 => s"sis",
+    r"([ti])a$"             => s"\1um",
+    r"s$"                   => s""]
+
+"""
+    singularize(word)
+
+Unpluralize a plural noun (given in canonical capitalization) using heuristics
+and lists of exceptions.
+
+```jldoctest
+julia> using EnglishText
+
+julia> singularize("foxes")
+"fox"
+
+julia> singularize("data")
+"datum"
+```
+"""
+function singularize(s::String)
+    # irregular words
+    for (singular, plural) in IRREGULAR_CLS
+        if plural == s
+            return singular
+        end
+    end
+    # words that do not inflect
+    if isnoninflecting(s, true) || isnoninflecting(s, false)
+        return s
+    end
+    # singular words ending in s
+    if endswith(s, "ses")
+        chopped = stem(s, 2, "")
+        if chopped ∈ SINGLE_S
+            return chopped
+        end
+    end
+    for (regex, subst) ∈ SINGULARIZE_RULES
+        if ismatch(regex, s)
+            return replace(s, regex, subst)
+        end
+    end
+    s
+end
+singularize(s::AbstractString) = singularize(String(s))

--- a/test/pluralize.jl
+++ b/test/pluralize.jl
@@ -1,31 +1,69 @@
+const UNIVERSAL_PLURALS = [
+    "agency" => "agencies",
+    "bacterium" => "bacteria",
+    "bias" => "biases",
+    "bison" => "bison",
+    "child" => "children",
+    "corps" => "corps",
+    "datum" => "data",
+    "deer" => "deer",
+    "diagnosis" => "diagnoses",
+    "die" => "dice",
+    "elf" => "elves",
+    "fish" => "fish",
+    "fizz" => "fizzes",
+    "foot" => "feet",
+    "gas" => "gases",
+    "goose" => "geese",
+    "graffito" => "graffiti",
+    "iron" => "irons",
+    "louse" => "lice",
+    "man" => "men",
+    "macro" => "macros",
+    "pig" => "pigs",
+    "sex" => "sexes",
+    "suffix" => "suffixes",    # "suffices" not standard Latin
+    "topaz" => "topazes",
+    "unicorn" => "unicorns",
+    "quiz" => "quizzes"]
+
+const CLASSICAL_PLURALS = [
+    "cactus" => "cacti",
+    "cow" => "kine",
+    "focus" => "foci",
+    "formula" => "formulae",
+    "genius" => "genii",
+    "money" => "monies",
+    "octopus" => "octopodes",  # "octopi" not standard Latin
+    "vertex" => "vertices"]
+
+const MODERN_PLURALS = [
+    "cactus" => "cactuses",
+    "cow" => "cows",
+    "focus" => "focuses",
+    "formula" => "formulas",
+    "genius" => "geniuses",
+    "money" => "moneys",
+    "octopus" => "octopuses",
+    "vertex" => "vertexes"]
+
 @testset "Pluralize" begin
-    @test pluralize("agency") == "agencies"
-    @test pluralize("bacterium") == "bacteria"
-    @test pluralize("bison") == "bison"
-    @test pluralize("cactus") == "cacti"
-    @test pluralize("child") == "children"
-    @test pluralize("corps") == "corps"
-    @test pluralize("cow") == "kine"
-    @test pluralize("datum") == "data"
-    @test pluralize("deer") == "deer"
-    @test pluralize("diagnosis") == "diagnoses"
-    @test pluralize("die") == "dice"
-    @test pluralize("elf") == "elves"
-    @test pluralize("fish") == "fish"
-    @test pluralize("focus") == "foci"
-    @test pluralize("foot") == "feet"
-    @test pluralize("formula") == "formulae"
-    @test pluralize("genius") == "genii"
-    @test pluralize("goose") == "geese"
-    @test pluralize("graffito") == "graffiti"
-    @test pluralize("iron") == "irons"
-    @test pluralize("louse") == "lice"
-    @test pluralize("man") == "men"
-    @test pluralize("macro") == "macros"
-    @test pluralize("money") == "monies"
-    @test pluralize("octopus") == "octopodes"  # "octopi" not standard Latin
-    @test pluralize("pig") == "pigs"
-    @test pluralize("suffix") == "suffixes"    # "suffices" not standard Latin
-    @test pluralize("unicorn") == "unicorns"
-    @test pluralize("vertex") == "vertices"
+    @testset for (singular, plural) in UNIVERSAL_PLURALS
+        @test pluralize(singular, classical=true) == plural
+        @test pluralize(singular, classical=false) == plural
+    end
+    @testset for (singular, plural) in CLASSICAL_PLURALS
+        @test pluralize(singular, classical=true) == plural
+    end
+    @testset for (singular, plural) in MODERN_PLURALS
+        @test pluralize(singular, classical=false) == plural
+    end
+end
+
+@testset "Singularize" begin
+    @testset for (singular, plural) in [UNIVERSAL_PLURALS;
+                                        CLASSICAL_PLURALS;
+                                        MODERN_PLURALS]
+        @test singularize(plural) == singular
+    end
 end


### PR DESCRIPTION
This implements an `singularize` function based off `singularize` from [Inflector .NET](https://github.com/srkirkland/Inflector) with some substantial improvements enabled by reusing some of the word tables used for the pluralizer. I've also taken the opportunity to fix some pluralization bugs and improve the test suite.

Closes #2 

cc @djsegal